### PR TITLE
Added alternative plaintext email template handling.

### DIFF
--- a/_build/data/properties/properties.forgotpassword.php
+++ b/_build/data/properties/properties.forgotpassword.php
@@ -42,6 +42,14 @@ $properties = array(
         'lexicon' => 'login:properties',
     ),
     array(
+        'name' => 'emailTplAlt',
+        'desc' => 'prop_forgotpassword.emailtplalt_desc',
+        'type' => 'textfield',
+        'options' => '',
+        'value' => '',
+        'lexicon' => 'login:properties',
+    ),
+    array(
         'name' => 'emailTplType',
         'desc' => 'prop_forgotpassword.emailtpltype_desc',
         'type' => 'list',

--- a/_build/data/properties/properties.register.php
+++ b/_build/data/properties/properties.register.php
@@ -185,6 +185,14 @@ $properties = array(
         'lexicon' => 'login:properties',
     ),
     array(
+        'name' => 'activationEmailTplAlt',
+        'desc' => 'prop_register.activationemailtplalt_desc',
+        'type' => 'textfield',
+        'options' => '',
+        'value' => '',
+        'lexicon' => 'login:properties',
+    ),
+    array(
         'name' => 'moderatedResourceId',
         'desc' => 'prop_register.moderatedresourceid_desc',
         'type' => 'textfield',

--- a/core/components/login/elements/snippets/forgotpassword.snippet.php
+++ b/core/components/login/elements/snippets/forgotpassword.snippet.php
@@ -37,6 +37,7 @@ $tplType = !empty($tplType) ? $tplType : 'modChunk';
 $sentTpl = !empty($sentTpl) ? $sentTpl : 'lgnForgotPassSentTpl';
 $sentTplType = !empty($sentTplType) ? $sentTplType : 'modChunk';
 $emailTpl = !empty($emailTpl) ? $emailTpl : 'lgnForgotPassEmail';
+$emailTplAlt = !empty($emailTplAlt) ? $emailTplAlt : '';
 $emailTplType = !empty($emailTplType) ? $emailTplType : 'modChunk';
 $emailSubject = !empty($emailSubject) ? $emailSubject : '';
 $resetResourceId = !empty($resetResourceId) ? $resetResourceId : 1;
@@ -108,6 +109,7 @@ if (!empty($_POST['login_fp_service'])) {
             $emailProperties['confirmUrl'] = $confirmUrl;
             $emailProperties['password'] = $pword;
             $emailProperties['tpl'] = $emailTpl;
+            $emailProperties['tplAlt'] = $emailTplAlt;
             $emailProperties['tplType'] = $emailTplType;
 
             /* now set new password to cache to prevent middleman attacks */

--- a/core/components/login/lexicon/en/properties.inc.php
+++ b/core/components/login/lexicon/en/properties.inc.php
@@ -5,6 +5,7 @@
  */
 /* ForgotPassword snippet */
 $_lang['prop_forgotpassword.emailtpl_desc'] = 'The confirmation email message tpl.';
+$_lang['prop_forgotpassword.emailtplalt_desc'] = '(optional) Plain text alternative for the confirmation email message tpl.';
 $_lang['prop_forgotpassword.emailtpltype_desc'] = 'The type of tpl being provided for the emailTpl property. Defaults to a Chunk.';
 $_lang['prop_forgotpassword.senttpl_desc'] = 'The message tpl to show when an email was successfully sent.';
 $_lang['prop_forgotpassword.senttpltype_desc'] = 'The type of tpl being provided for the sentTpl property. Defaults to a Chunk.';
@@ -61,6 +62,7 @@ $_lang['prop_register.activationemail_desc'] = 'If set, will sent activation ema
 $_lang['prop_register.activationemailsubject_desc'] = 'The subject of the activation email.';
 $_lang['prop_register.activationemailtpltype_desc'] = 'The type of tpls being provided for the activation email.';
 $_lang['prop_register.activationemailtpl_desc'] = 'The activation email tpl.';
+$_lang['prop_register.activationemailtplalt_desc'] = '(optional) Platin text alternative for the activation email tpl.';
 $_lang['prop_register.moderatedresourceid_desc'] = 'If a prehook sets the user as moderated, then send to this Resource instead of the submittedResourceId. Leave blank to bypass.';
 $_lang['prop_register.placeholderprefix_desc'] = 'The prefix to use for all placeholders set by this snippet.';
 $_lang['prop_register.recaptchaheight_desc'] = 'If `recaptcha` is set as a preHook, this will select the height for the reCaptcha widget.';

--- a/core/components/login/model/login/login.class.php
+++ b/core/components/login/model/login/login.class.php
@@ -115,9 +115,11 @@ class Login {
         if (empty($properties['tplType'])) $properties['tplType'] = 'modChunk';
 
         $msg = $this->getChunk($properties['tpl'],$properties,$properties['tplType']);
+        if (!empty($properties['tplAlt'])) $msgAlt = $this->getChunk($properties['tplAlt'],$properties,$properties['tplType']);
 
         $this->modx->getService('mail', 'mail.modPHPMailer');
         $this->modx->mail->set(modMail::MAIL_BODY, $msg);
+        if (!empty($msgAlt)) $this->modx->mail->set(modMail::MAIL_BODY_TEXT, $msgAlt);
         $this->modx->mail->set(modMail::MAIL_FROM, $this->modx->getOption('emailsender'));
         $this->modx->mail->set(modMail::MAIL_FROM_NAME, $this->modx->getOption('site_name'));
         $this->modx->mail->set(modMail::MAIL_SENDER, $this->modx->getOption('emailsender'));

--- a/core/components/login/processors/register.php
+++ b/core/components/login/processors/register.php
@@ -140,10 +140,12 @@ if ($activation && !empty($email) && !empty($activateResourceId) && empty($field
 
     /* set confirmation email properties */
     $emailTpl = $modx->getOption('activationEmailTpl',$scriptProperties,'lgnActivateEmailTpl');
+    $emailTplAlt = $modx->getOption('activationEmailTplAlt',$scriptProperties,'');
     $emailTplType = $modx->getOption('activationEmailTplType',$scriptProperties,'modChunk');
     $emailProperties = $user->toArray();
     $emailProperties['confirmUrl'] = $confirmUrl;
     $emailProperties['tpl'] = $emailTpl;
+    $emailProperties['tplAlt'] = $emailTplAlt;
     $emailProperties['tplType'] = $emailTplType;
     $emailProperties['password'] = $fields['password'];
 


### PR DESCRIPTION
(optional)  when set - it will send email as multitype using both defined templates (HTML and plaintext) in one email.
