### PR TITLE
References of the user and profile objects and the usernameChange

### DIFF
--- a/core/components/login/processors/UpdateProfile.php
+++ b/core/components/login/processors/UpdateProfile.php
@@ -185,10 +185,11 @@ class LoginUpdateProfileProcessor extends LoginProcessor {
     public function runPostHooks() {
         $postHooks = $this->controller->getProperty('postHooks','');
         $this->controller->loadHooks('postHooks');
+        $fields = $this->dictionary->toArray();
         $fields['updateprofile.user'] = &$this->modx->user;
         $fields['updateprofile.profile'] =& $this->profile;
         $fields['updateprofile.usernameChanged'] = $this->usernameChanged;
-        $this->controller->postHooks->loadMultiple($postHooks,$this->dictionary->toArray());
+        $this->controller->postHooks->loadMultiple($postHooks,$fields);
 
         /* process hooks */
         if ($this->controller->postHooks->hasErrors()) {


### PR DESCRIPTION
Fixed: references of the user and profile objects and the usernameChanged back in the in the postHooks
