### PR TITLE
Fixed none-array getExtended() method

### DIFF
--- a/core/components/login/controllers/web/Profile.php
+++ b/core/components/login/controllers/web/Profile.php
@@ -88,7 +88,7 @@ class LoginProfileController extends LoginController {
         if ($this->getProperty('useExtended',true,'isset')) {
             $extended = $this->profile->get('extended');
         }
-        return $extended;
+        return (array) $extended;
     }
 
     /**


### PR DESCRIPTION
Force returning an array in getExtended() method. To avoid array_merge() problems on line 66
