### PR TITLE
Fix bug with ConfirmRegister logging in user as (anonymous)

### DIFF
--- a/core/components/login/controllers/web/ConfirmRegister.php
+++ b/core/components/login/controllers/web/ConfirmRegister.php
@@ -161,7 +161,7 @@ class LoginConfirmRegisterController extends LoginController {
      */
     public function addSessionContexts() {
         if ($this->getProperty('authenticate',true,'isset')) {
-            $this->modx->user =& $user;
+            $this->modx->user =& $this->user;
             $this->modx->getUser();
             $contexts = $this->getProperty('authenticateContexts',$this->modx->context->get('key'));
             $contexts = explode(',',$contexts);


### PR DESCRIPTION
This bug fix is important for people who want to show users information or protected pages when they confirm registration.
