### PR TITLE
Update loginvalidator.class.php

### DIFF
--- a/core/components/login/model/login/loginvalidator.class.php
+++ b/core/components/login/model/login/loginvalidator.class.php
@@ -687,7 +687,7 @@ class LoginValidator {
      * @param array $properties
      * @return null|string
      */
-    protected function _getErrorMessage($field,$parameter,$lexiconKey,array $properties = array()) {
+    public function _getErrorMessage($field,$parameter,$lexiconKey,array $properties = array()) {
         if (!empty($this->login->config[$field.'.'.$parameter])) {
             $message = $this->login->config[$field.'.'.$parameter];
             $this->modx->lexicon->set($lexiconKey,$message);


### PR DESCRIPTION
Change _getErrorMessage() protected into public, to make it available for third party validators (same as I did for FormIt ;-))
