### PR TITLE
* Prevent double URL encoding of username and password in activation link

### DIFF
--- a/core/components/login/controllers/web/ForgotPassword.php
+++ b/core/components/login/controllers/web/ForgotPassword.php
@@ -209,8 +209,8 @@ class LoginForgotPasswordController extends LoginController {
         /* generate a password and encode it and the username into the url */
         $password = $this->login->generatePassword();
         $confirmParams = array(
-            'lp' => urlencode(base64_encode($password)),
-            'lu' => urlencode(base64_encode($fields['username']))
+            'lp' => base64_encode($password),
+            'lu' => base64_encode($fields['username'])
         );
         $confirmUrl = $this->modx->makeUrl($this->getProperty('resetResourceId',1),'',$confirmParams,'full');
 


### PR DESCRIPTION
Hi Shaun,

The URL encoding at this spot adds up to the standard URL encoding done in `http_build_query` which is used through the `$modx->makUrl` handler.

Making activation links end up with double-url-encoded "=" characters (%253D instead of %3D) originating from the base64 encoding.

These double URL encoded query string fragments are not supported by all browsers. Giving end users a hard time resetting their password.

Can you please review?
Thanks,
Maarten
