### PR TITLE
Added Romanian translation for Login.ForgotPassword

### DIFF
--- a/core/components/login/lexicon/ro/forgotpassword.inc.php
+++ b/core/components/login/lexicon/ro/forgotpassword.inc.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Login
+ *
+ * Copyright 2010 by Jason Coward <jason@modxcms.com> and Shaun McCormick
+ * <shaun@modxcms.com>
+ *
+ * Login is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option) any
+ * later version.
+ *
+ * Login is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * Login; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ * @package login
+ */
+/**
+ * Forgot Password English lexicon for Login
+ *
+ * @package login
+ * @subpackage lexicon
+ * @author Radu Dumbrăveanu <vundicind@gmail.com>
+ */
+$_lang['login.email'] = 'Adresa de e-mail';
+$_lang['login.forgot_password'] = 'Ați uitat parola?';
+$_lang['login.forgot_password_email_subject'] = 'Adresa de e-mail pentru recuperarea parolei';
+$_lang['login.or_forgot_username'] = 'Ați uitat și numele dvs. de utilizator?';
+$_lang['login.reset_password'] = 'Resetează parola';
+$_lang['login.username'] = 'Nume de utilizator';
+$_lang['login.user_err_nf_email'] = 'Nu există utilizator cu adresa de e-mail furnizată.';
+$_lang['login.user_err_nf_username'] = 'Nu există utilizator cu numele furnizat.';


### PR DESCRIPTION
Translated `lexicon/en/forgotpassword.inc.php` into Romanian.
